### PR TITLE
Shuffle deck when deckGetById is called

### DIFF
--- a/models/DataModels.go
+++ b/models/DataModels.go
@@ -3,6 +3,8 @@ package models
 import (
 	"gorm.io/gorm"
 	"reflect"
+    "math/rand"
+    "time"
 )
 
 type Deck struct {
@@ -11,6 +13,14 @@ type Deck struct {
 	Description string
 	FlashCards  []FlashCard `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
 	OwnerId     uint
+}
+
+func (d *Deck) Shuffle() {
+    deck := d  // For some reason, I have to to this for the anonymous function below to recognize the deck
+    rand.Seed(time.Now().UnixNano())
+    rand.Shuffle(len(d.FlashCards), func(i, j int) {
+        deck.FlashCards[i], deck.FlashCards[j] = deck.FlashCards[j], deck.FlashCards[i]
+    })
 }
 
 func (d *Deck) CopyReferences(o *Deck) {

--- a/web/api.go
+++ b/web/api.go
@@ -92,8 +92,11 @@ func deckGetById(cfg *Global.Configuration) fiber.Handler {
 
 		if deckId, err := strconv.ParseUint(c.Params("id", "0"), 10, 64); err == nil {
 			cfg.DeckRepo.GetDeckById(&deck, uint(deckId))
-            deck.Shuffle()
 			id := c.Locals(USER_ID).(uint)
+            shouldShuffle := c.Params("shuffle")
+            if shouldShuffle == "true" {
+                deck.Shuffle()
+            }
 
 			if deck.OwnerId == id {
 				return c.Status(fiber.StatusOK).JSON(&deck)

--- a/web/api.go
+++ b/web/api.go
@@ -73,7 +73,6 @@ func deckPost(cfg *Global.Configuration) fiber.Handler {
 				return c.Status(fiber.StatusCreated).SendString(location)
 			}
 		}
-
 		return c.SendStatus(fiber.StatusBadRequest)
 	}
 }
@@ -93,6 +92,7 @@ func deckGetById(cfg *Global.Configuration) fiber.Handler {
 
 		if deckId, err := strconv.ParseUint(c.Params("id", "0"), 10, 64); err == nil {
 			cfg.DeckRepo.GetDeckById(&deck, uint(deckId))
+            deck.Shuffle()
 			id := c.Locals(USER_ID).(uint)
 
 			if deck.OwnerId == id {


### PR DESCRIPTION
Worth considering: are there cases where we'd want to call `deckGetById` without shuffling? If so this would need to be changed a bit.