### PR TITLE
Broadcast upon joining

### DIFF
--- a/web/connectionHub.go
+++ b/web/connectionHub.go
@@ -49,7 +49,6 @@ func handleRegistration(connection *models.UserConnection) {
 	_ = connection.Connection.WriteJSON(connectMessage)
 
     // broadcast username so frontend can notify user when someone joins room
-    // new idea: use the connectedusers in the room struct to send all connected users
     type ToBroadcast struct {
         Users map[uint]string `json:"users"`
     }

--- a/web/connectionHub.go
+++ b/web/connectionHub.go
@@ -48,6 +48,14 @@ func handleRegistration(connection *models.UserConnection) {
 	}
 	_ = connection.Connection.WriteJSON(connectMessage)
 
+    // broadcast username so frontend can notify user when someone joins room
+    // new idea: use the connectedusers in the room struct to send all connected users
+    type ToBroadcast struct {
+        Users map[uint]string `json:"users"`
+    }
+    usernameJSON := ToBroadcast{Users: entry.ConnectedUsers}
+    entry.WriteJsonToAllConnections(usernameJSON)
+
 	connection.Logger.Println("Connection registered to new room")
 }
 

--- a/web/connectionHub.go
+++ b/web/connectionHub.go
@@ -48,7 +48,7 @@ func handleRegistration(connection *models.UserConnection) {
 	}
 	_ = connection.Connection.WriteJSON(connectMessage)
 
-    // broadcast username so frontend can notify user when someone joins room
+    // broadcast usernames so frontend can show connected users in waiting room
     type ToBroadcast struct {
         Users map[uint]string `json:"users"`
     }


### PR DESCRIPTION
Gonna need to do something like this, at any rate. Maybe it would be more consistent to have the ToBroadcast struct in hubModels.go, also, so I suppose you can move that there if you want.