### PR TITLE
Flatten some json and change Task to MessageType

### DIFF
--- a/models/hubModels.go
+++ b/models/hubModels.go
@@ -88,30 +88,25 @@ type UserConnection struct {
 	Username   string
 }
 
-// I don't like having a separate type for the contents but don't know any
-// other way to do this --Joe
-type InitialConnectionContents struct {
+type InitialConnection struct {
+    MessageType string `json:"message_type"`
     Action   string         `json:"action"`
     Admin    bool           `json:"admin"`
     Question string         `json:"question"`
     Answers  []AnswerChoice `json:"answers"`
 }
-type InitialConnection struct {
-    MessageType string `json:"message_type"`
-    Contents InitialConnectionContents `json:"contents"`
-}
 type AnswerChoice struct{}
 type Client struct{} // Add more data to this type if needed
 
 type LoadDeck struct {
-	Task  string
-	Deck  []FlashCard
-	Count int
+    MessageType  string `json:"message_type"`
+    Deck  []FlashCard `json:"deck"`
+    Count int `json:"count"`
 }
 
 func NewLoadDeck(d []FlashCard) LoadDeck {
 	return LoadDeck{
-		Task:  "QUESTIONS",
+		MessageType:  "questions",
 		Deck:  d,
 		Count: len(d),
 	}

--- a/web/connectionHub.go
+++ b/web/connectionHub.go
@@ -45,10 +45,8 @@ func handleRegistration(connection *models.UserConnection) {
 	// And if we already have a channel, then they're not the first person
 	connectMessage := models.InitialConnection{
         MessageType: "initial-connection",
-        Contents: models.InitialConnectionContents{
-            Action: "REGISTERED",
-            Admin:  connection.UserId == entry.AdminId, //!keyExists,
-        },
+        Action: "REGISTERED",
+        Admin:  connection.UserId == entry.AdminId, //!keyExists,
 	}
 	if err := connection.Connection.WriteJSON(connectMessage); err != nil {
 		Configs.Logger.Println(err)


### PR DESCRIPTION
Makes the `LoadDeck` struct consistent with the `{message_type: "something", [other stuff]}` format I'm going for. I also realized I could flatten the `InitialConnection` struct without causing any harm. I'm using this branch to pass the deck to the frontend.